### PR TITLE
Try memoizing layout engine

### DIFF
--- a/.changeset/spicy-rockets-live.md
+++ b/.changeset/spicy-rockets-live.md
@@ -1,0 +1,6 @@
+---
+'@nutshelllabs/textkit': minor
+'@nutshelllabs/fns': minor
+---
+
+Memoized the layout engine computation for faster renders of the same document multiple times. The cache is implemented as LRU.

--- a/packages/fns/src/index.js
+++ b/packages/fns/src/index.js
@@ -14,3 +14,5 @@ export { default as omit } from './omit';
 export { default as pick } from './pick';
 export { default as reverse } from './reverse';
 export { default as upperFirst } from './upperFirst';
+export { default as LRUCache } from './lruCache';
+export { default as memoize } from './memoize';

--- a/packages/fns/src/lruCache.js
+++ b/packages/fns/src/lruCache.js
@@ -1,0 +1,34 @@
+class LRUCache {
+  constructor(capacity = 1000) {
+    this.capacity = capacity;
+    this.cache = new Map();
+  }
+
+  get(key) {
+    if (this.cache.has(key)) {
+      const value = this.cache.get(key);
+      this.cache.delete(key);
+      this.cache.set(key, value);
+      return value;
+    }
+    return undefined;
+  }
+
+  set(key, val) {
+    if (this.cache.size >= this.capacity) {
+      this.cache.delete(this.first());
+    }
+    this.cache.delete(key);
+    this.cache.set(key, val);
+  }
+
+  has(key) {
+    return this.cache.has(key);
+  }
+
+  first() {
+    return this.cache.keys().next().value;
+  }
+}
+
+export default LRUCache;

--- a/packages/fns/src/memoize.js
+++ b/packages/fns/src/memoize.js
@@ -1,0 +1,71 @@
+import LRUCache from './lruCache';
+
+/**
+ * Copied in from lodash https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10540
+ *
+ * Creates a function that memoizes the result of `func`. If `resolver` is
+ * provided, it determines the cache key for storing the result based on the
+ * arguments provided to the memoized function. By default, the first argument
+ * provided to the memoized function is used as the map cache key. The `func`
+ * is invoked with the `this` binding of the memoized function.
+ *
+ * **Note:** The cache is exposed as the `cache` property on the memoized
+ * function. Its creation may be customized by replacing the `_.memoize.Cache`
+ * constructor with one whose instances implement the
+ * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
+ * method interface of `clear`, `delete`, `get`, `has`, and `set`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to have its output memoized.
+ * @param {Function} [resolver] The function to resolve the cache key.
+ * @returns {Function} Returns the new memoized function.
+ * @example
+ *
+ * var object = { 'a': 1, 'b': 2 };
+ * var other = { 'c': 3, 'd': 4 };
+ *
+ * var values = _.memoize(_.values);
+ * values(object);
+ * // => [1, 2]
+ *
+ * values(other);
+ * // => [3, 4]
+ *
+ * object.a = 2;
+ * values(object);
+ * // => [1, 2]
+ *
+ * // Modify the result cache.
+ * values.cache.set(object, ['a', 'b']);
+ * values(object);
+ * // => ['a', 'b']
+ *
+ * // Replace `_.memoize.Cache`.
+ * _.memoize.Cache = WeakMap;
+ */
+function memoize(func, resolver) {
+  if (
+    typeof func !== 'function' ||
+    (resolver != null && typeof resolver !== 'function')
+  ) {
+    throw new TypeError('Expected a function');
+  }
+  function memoized(...args) {
+    const key = resolver ? resolver.apply(this, args) : args[0];
+    const { cache } = memoized;
+
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const result = func.apply(this, args);
+    memoized.cache = cache.set(key, result) || cache;
+    return result;
+  }
+  memoized.cache = new (memoize.Cache || LRUCache)();
+  return memoized;
+}
+
+export default memoize;

--- a/packages/fns/tests/lru.test.js
+++ b/packages/fns/tests/lru.test.js
@@ -1,0 +1,27 @@
+import LRUCache from '../src/lruCache';
+
+describe('LRUCache', () => {
+  test('should set and get and evict', () => {
+    const cache = new LRUCache(2);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    expect(cache.get('a')).toBe(undefined);
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+  });
+  test('should evict least recently accessed', () => {
+    const cache = new LRUCache(2);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a'); // b is now the least recently accessed
+    cache.set('c', 3);
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBe(undefined);
+    expect(cache.get('c')).toBe(3);
+  });
+});

--- a/packages/fns/tests/memoize.test.js
+++ b/packages/fns/tests/memoize.test.js
@@ -1,0 +1,26 @@
+import memoize from '../src/memoize';
+
+describe('memoize', () => {
+  test('should memoize results based on the first argument provided', () => {
+    const fn = jest.fn((a, b) => a + b);
+    const memoized = memoize(fn);
+
+    expect(memoized(1, 2)).toBe(3);
+    expect(memoized(1, 2)).toBe(3);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    expect(memoized(2, 3)).toBe(5);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+  test('should allow a custom resolver to be provided', () => {
+    const fn = jest.fn((a, b, c) => a + b + c);
+    const memoized = memoize(fn, (...args) => args.sort().join(','));
+
+    expect(memoized(1, 2, 3)).toBe(6);
+    expect(memoized(3, 2, 1)).toBe(6);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    expect(memoized(2, 3, 0)).toBe(5);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
This looks pretty good, a 38% improvement.  I'm going to and verify more documents just to make sure I haven't done anything dumb, but it looks promising.

<details><summary>Before</summary>
<p>

```js
{
  title: 'docgen benchmark test',
  url: 'http://localhost:3001/generate',
  socketPath: undefined,
  connections: 1,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 21.01,
  samples: 21,
  start: 2023-06-23T23:08:28.829Z,
  finish: 2023-06-23T23:08:49.843Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 200,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 200 } },
  latency: {
    average: 102.43,
    mean: 102.43,
    stddev: 16.19,
    min: 90,
    max: 269,
    p0_001: 90,
    p0_01: 90,
    p0_1: 90,
    p1: 91,
    p2_5: 92,
    p10: 95,
    p25: 97,
    p50: 99,
    p75: 102,
    p90: 108,
    p97_5: 131,
    p99: 174,
    p99_9: 269,
    p99_99: 269,
    p99_999: 269,
    totalCount: 200
  },
  requests: {
    average: 9.53,
    mean: 9.53,
    stddev: 1.44,
    min: 5,
    max: 11,
    total: 200,
    p0_001: 5,
    p0_01: 5,
    p0_1: 5,
    p1: 5,
    p2_5: 5,
    p10: 9,
    p25: 9,
    p50: 10,
    p75: 10,
    p90: 11,
    p97_5: 11,
    p99: 11,
    p99_9: 11,
    p99_99: 11,
    p99_999: 11,
    sent: 200
  },
  throughput: {
    average: 146185.15,
    mean: 146185.15,
    stddev: 22023.11,
    min: 76776,
    max: 169120,
    total: 3069900,
    p0_001: 76799,
    p0_01: 76799,
    p0_1: 76799,
    p1: 76799,
    p2_5: 76799,
    p10: 138239,
    p25: 138367,
    p50: 153471,
    p75: 153599,
    p90: 168831,
    p97_5: 169215,
    p99: 169215,
    p99_9: 169215,
    p99_99: 169215,
    p99_999: 169215
  }
}

```

</p>
</details>

<details><summary>After</summary>
<p>

```js
{
  title: 'docgen benchmark test',
  url: 'http://localhost:3001/generate',
  socketPath: undefined,
  connections: 1,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 13.01,
  samples: 13,
  start: 2023-06-23T23:06:20.632Z,
  finish: 2023-06-23T23:06:33.645Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 200,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 200 } },
  latency: {
    average: 63.87,
    mean: 63.87,
    stddev: 13.35,
    min: 56,
    max: 156,
    p0_001: 56,
    p0_01: 56,
    p0_1: 56,
    p1: 56,
    p2_5: 57,
    p10: 59,
    p25: 59,
    p50: 61,
    p75: 63,
    p90: 66,
    p97_5: 87,
    p99: 141,
    p99_9: 156,
    p99_99: 156,
    p99_999: 156,
    totalCount: 200
  },
  requests: {
    average: 15.39,
    mean: 15.39,
    stddev: 1.01,
    min: 14,
    max: 17,
    total: 200,
    p0_001: 14,
    p0_01: 14,
    p0_1: 14,
    p1: 14,
    p2_5: 14,
    p10: 14,
    p25: 15,
    p50: 15,
    p75: 16,
    p90: 17,
    p97_5: 17,
    p99: 17,
    p99_9: 17,
    p99_99: 17,
    p99_999: 17,
    sent: 200
  },
  throughput: {
    average: 235692.31,
    mean: 235692.31,
    stddev: 15342.26,
    min: 214428,
    max: 260488,
    total: 3063892,
    p0_001: 214527,
    p0_01: 214527,
    p0_1: 214527,
    p1: 214527,
    p2_5: 214527,
    p10: 214527,
    p25: 229759,
    p50: 230015,
    p75: 245247,
    p90: 260351,
    p97_5: 260607,
    p99: 260607,
    p99_9: 260607,
    p99_99: 260607,
    p99_999: 260607
  }
}

```

</p>
</details> 