### PR TITLE
Rewrite omit

### DIFF
--- a/packages/textkit/src/run/omit.js
+++ b/packages/textkit/src/run/omit.js
@@ -5,11 +5,9 @@
  * @return {Object} run without ommited attribute
  */
 const omit = (value, run) => {
-  const attributes = Object.assign({}, run.attributes);
-
-  delete attributes[value];
-
-  return Object.assign({}, run, { attributes });
+  const newAttributes = {...run.attributes};
+  delete newAttributes[value];
+  return {...run, attributes: newAttributes};
 };
 
 export default omit;


### PR DESCRIPTION
**Before**

chrome profile on mac of benchmark showed `omit` is 5.1% of `runMicrotasks`

Benchmark results:

```
  latency: {
    average: 97.1,
    mean: 97.1,
    stddev: 11.75,
    min: 90,
    max: 227,
```

**After**

profile shows `omit` is 0.9% of `runMicrotasks`

```
  latency: {
    average: 90.64,
    mean: 90.64,
    stddev: 6.6,
    min: 84,
    max: 140,
```
