### PR TITLE
skip list reverse in function compose utils

### DIFF
--- a/.changeset/silly-walls-mix.md
+++ b/.changeset/silly-walls-mix.md
@@ -1,0 +1,6 @@
+---
+'@nutshelllabs/textkit': minor
+'@nutshelllabs/renderer': minor
+---
+
+Minor perf opt and compress=false default in renderToStream

--- a/packages/fns/src/asyncCompose.js
+++ b/packages/fns/src/asyncCompose.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-await-in-loop */
 
-import reverse from './reverse';
-
 /**
  * Performs right-to-left function composition with async functions support
  *
@@ -9,10 +7,9 @@ import reverse from './reverse';
  */
 const asyncCompose = (...fns) => async (value, ...args) => {
   let result = value;
-  const reversedFns = reverse(fns);
 
-  for (let i = 0; i < reversedFns.length; i += 1) {
-    const fn = reversedFns[i];
+  for (let i = fns.length - 1; i >= 0; i -= 1) {
+    const fn = fns[i];
     result = await fn(result, ...args);
   }
 

--- a/packages/fns/src/compose.js
+++ b/packages/fns/src/compose.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-await-in-loop */
 
-import reverse from './reverse';
-
 /**
  * Performs right-to-left function composition
  *
@@ -9,10 +7,9 @@ import reverse from './reverse';
  */
 const compose = (...fns) => (value, ...args) => {
   let result = value;
-  const reversedFns = reverse(fns);
 
-  for (let i = 0; i < reversedFns.length; i += 1) {
-    const fn = reversedFns[i];
+  for (let i = fns.length - 1; i >= 0; i -= 1) {
+    const fn = fns[i];
     result = fn(result, ...args);
   }
 

--- a/packages/textkit/src/run/flatten.js
+++ b/packages/textkit/src/run/flatten.js
@@ -6,7 +6,6 @@ const EMPTY_RES = [];
 
 /**
  * Flatten many runs
-  return emptyRuns.concat(regularRuns);
  *
  * @param  {Array}  runs
  * @return {Array} flatten runs


### PR DESCRIPTION
Reverse util copies the list which makes garbage. This is used by the compose utils which can simply iterate the list backwards instead.