### PR TITLE
Adds ability for docgen to render the taxdoc with a watermark

### DIFF
--- a/packages/layout/src/image/fetchImage.js
+++ b/packages/layout/src/image/fetchImage.js
@@ -27,7 +27,8 @@ const fetchImage = async node => {
       throw new Error(`Image's "src" or "source" prop returned ${source}`);
     }
 
-    node.image = await resolveImage(source, { cache });
+    const nodeCacheId = node.props.cacheId;
+    node.image = await resolveImage(source, { cache, cacheId: nodeCacheId });
     node.image.key = source.data ? source.data.toString() : source.uri;
   } catch (e) {
     node.image = { width: 0, height: 0, key: null };

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -124,6 +124,12 @@ declare namespace ReactPDF {
      */
     debug?: boolean;
     cache?: boolean;
+    /**
+     * Allows to specify a custom cache ID for the image.
+     * This is particularly useful because images are cached based on their src value
+     * which causes problems when you need to render the same image multiple times with different css properties such as a watermark.
+     */
+    cacheId?: string;
   }
 
   interface ImageWithSrcProp extends BaseImageProps {


### PR DESCRIPTION
Adds ability for docgen to render the taxdoc with a watermark

- Modified fetchImages to cache images using a cacheId prop - this allows image components using the same image file to be cached individually
- Added a verification step for Image nodes to avoid trying to render an image node without image data