### PR TITLE
Revert some in place optimizations

### DIFF
--- a/.changeset/brown-balloons-trade.md
+++ b/.changeset/brown-balloons-trade.md
@@ -1,0 +1,5 @@
+---
+'@nutshelllabs/render': patch
+---
+
+Revert some performance optimizations in renderGlyphs. Seems like a negligible change, and fixes the `fixed` component display issues

--- a/packages/render/src/primitives/renderGlyphs.js
+++ b/packages/render/src/primitives/renderGlyphs.js
@@ -5,13 +5,15 @@ const renderGlyphs = (ctx, glyphs, positions, x, y, options = {}) => {
 
   // Glyph encoding and positioning
   const encodedGlyphs = ctx._font.encodeGlyphs(glyphs);
-  positions.forEach((pos, i) => {
-    pos.xAdvance *= scale;
-    pos.yAdvance *= scale;
-    pos.advanceWidth = glyphs[i].advanceWidth * advanceWidthScale;
-  });
+  const encodedPositions = positions.map((pos, i) => ({
+    xAdvance: pos.xAdvance * scale,
+    yAdvance: pos.yAdvance * scale,
+    xOffset: pos.xOffset,
+    yOffset: pos.yOffset,
+    advanceWidth: glyphs[i].advanceWidth * advanceWidthScale,
+  }));
 
-  return ctx._glyphs(encodedGlyphs, positions, x, y, options);
+  return ctx._glyphs(encodedGlyphs, encodedPositions, x, y, options);
 };
 
 export default renderGlyphs;


### PR DESCRIPTION
As it turns out, this function was the culprit behind the layout issues seen when adding the `fixed` prop to a component.

My theory for why this caused the problem is that when you have a component with the `fixed` prop, react-pdf will render the same component on multiple pages.  I think if we modify the object here in place, it will get overwritten by the values from subsequent pages.

See https://react-pdf.org/advanced for some more info on `fixed`.

There could be more issues that present themselves along these lines, so just for easy navigating, the commit with all the changes is https://github.com/nutshelllabs/react-pdf/commit/bbb841559d96a429e6b7d31808c831459b1bb061